### PR TITLE
GitHub Followers

### DIFF
--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -10,7 +10,13 @@ class UserFacade
     end.take(5)
   end
 
-private
+  def followers
+    service = GithubApiService.new
+    service.get_user_followers.map do |data|
+      Follower.new(data)
+    end
+  end
 
+private
   attr_reader :current_user
 end

--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -1,0 +1,8 @@
+class Follower
+  attr_reader :login, :html_url
+
+  def initialize(data = {})
+    @login = data[:login]
+    @html_url = data[:html_url]
+  end
+end

--- a/app/services/github_api_service.rb
+++ b/app/services/github_api_service.rb
@@ -3,6 +3,10 @@ class GithubApiService
     get_response('/user/repos')
   end
 
+  def get_user_followers
+    get_response('/user/followers')
+  end
+
   private
 
   def get_response(url)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,13 +9,19 @@
   </ul>
   <%= button_to 'Connect to Github', '/auth/github' %>
   <% if  current_user.github_token != nil %>
-    <section>
+    <section class='github'>
       <h2>GitHub</h2>
-      <% facade.repos.each do |r| %>
-      <ul class='repo'>
-        <li class='name'><%= link_to r.name, "#{r.html_url}" %></li>
-        </ul>
-      <% end %>
+        <% facade.repos.each do |r| %>
+          <ul class='repo'>
+            <li class='name'><%= link_to r.name, "#{r.html_url}" %></li>
+          </ul>
+        <% end %>
+        <h2>Followers</h2>
+        <% facade.followers.each do |f| %>
+          <ul class='followers'>
+            <li class='user'><%= link_to f.login, "#{f.html_url}" %></li>
+          </ul>
+        <% end %>
     </section>
   <% end %>
   <section>

--- a/fixtures/github_followers.json
+++ b/fixtures/github_followers.json
@@ -1,0 +1,42 @@
+[
+    {
+        "login": "HeatherHerries",
+        "id": 23111126,
+        "node_id": "MDQ6VXNlcjIzMTExMTI2",
+        "avatar_url": "https://avatars2.githubusercontent.com/u/23111126?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/HeatherHerries",
+        "html_url": "https://github.com/HeatherHerries",
+        "followers_url": "https://api.github.com/users/HeatherHerries/followers",
+        "following_url": "https://api.github.com/users/HeatherHerries/following{/other_user}",
+        "gists_url": "https://api.github.com/users/HeatherHerries/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/HeatherHerries/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/HeatherHerries/subscriptions",
+        "organizations_url": "https://api.github.com/users/HeatherHerries/orgs",
+        "repos_url": "https://api.github.com/users/HeatherHerries/repos",
+        "events_url": "https://api.github.com/users/HeatherHerries/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/HeatherHerries/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    {
+        "login": "anlewis",
+        "id": 26888961,
+        "node_id": "MDQ6VXNlcjI2ODg4OTYx",
+        "avatar_url": "https://avatars3.githubusercontent.com/u/26888961?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/anlewis",
+        "html_url": "https://github.com/anlewis",
+        "followers_url": "https://api.github.com/users/anlewis/followers",
+        "following_url": "https://api.github.com/users/anlewis/following{/other_user}",
+        "gists_url": "https://api.github.com/users/anlewis/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/anlewis/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/anlewis/subscriptions",
+        "organizations_url": "https://api.github.com/users/anlewis/orgs",
+        "repos_url": "https://api.github.com/users/anlewis/repos",
+        "events_url": "https://api.github.com/users/anlewis/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/anlewis/received_events",
+        "type": "User",
+        "site_admin": false
+    }
+]

--- a/spec/features/user/user_can_see_github_followers_spec.rb
+++ b/spec/features/user/user_can_see_github_followers_spec.rb
@@ -1,0 +1,36 @@
+# As a logged in user
+# When I visit /dashboard
+# Then I should see a section for "Github"
+# And under that section I should see another section titled "Followers"
+# And I should see list of all followers with their handles linking to their Github profile
+require 'rails_helper'
+
+describe 'User Dashboard View' do
+  describe 'As a logged in user visiting my dashboard' do
+    before :each do
+      repos_response = File.open("./fixtures/github_repo.json")
+      stub_request(:get, "https://api.github.com/user/repos").to_return(status: 200, body: repos_response)
+      followers_response = File.open("./fixtures/github_followers.json")
+      stub_request(:get, "https://api.github.com/user/followers").to_return(status: 200, body: followers_response)
+    end
+
+    it 'I should see a Followers section within the GitHub section with all my followers and links to their profile' do
+      user = User.create!(first_name: 'Bob', last_name: 'Ross', password: 'HappyTree', github_token: '12345', email: 'Mr.Ross@gmail.com')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      expect(current_path).to eq(dashboard_path)
+      expect(page).to have_content('GitHub')
+
+      within(".github") do
+        expect(page).to have_content('Followers')
+      end
+
+      within(first('.followers')) do
+        expect(page).to have_css('.user')
+        expect(page).to have_link('HeatherHerries')
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_see_github_repos_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 describe 'User Dashboard View' do
   describe 'As a logged in user, when I visit /dashboard' do
     before :each do
-      json_response = File.open("./fixtures/github_repo.json")
-      stub_request(:get, "https://api.github.com/user/repos").to_return(status: 200, body: json_response)
+      repos_response = File.open("./fixtures/github_repo.json")
+      stub_request(:get, "https://api.github.com/user/repos").to_return(status: 200, body: repos_response)
+      followers_response = File.open("./fixtures/github_followers.json")
+      stub_request(:get, "https://api.github.com/user/followers").to_return(status: 200, body: followers_response)
     end
 
     it 'Then I should see a section for "Github" with 5 repo names' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,9 +18,9 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.filter_sensitive_data("<YOUTUBE_API_KEY>") { ENV['YOUTUBE_API_KEY'] }
-  config.filter_sensitive_data("<USER_GITHUB_API_KEY>") {ENV['USER_GITHUB_API_KEY']}
-  config.filter_sensitive_data("<GITHUB_KEY>") {ENV['GITHUB_KEY']}
-  config.filter_sensitive_data("<GITHUB_SECRET>") {ENV['GITHUB_SECRET']}
+  config.filter_sensitive_data("<USER_GITHUB_API_KEY>") { ENV['USER_GITHUB_API_KEY'] }
+  config.filter_sensitive_data("<GITHUB_KEY>") { ENV['GITHUB_KEY'] }
+  config.filter_sensitive_data("<GITHUB_SECRET>") { ENV['GITHUB_SECRET'] }
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
Functionality complete
*Adds Follower PORO
*Adds Followers to Show view
*Adds #get_user_followers actions to our GitHub Api Service
*Adds fixture for our stubbed response
*Adds Followers action to Facade sho that they can be displayed
*Adds spec file to test all the above
*All tests passing